### PR TITLE
Parse rendered html

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@jupyterlab/application": "^0.15.0",
     "@jupyterlab/apputils": "^0.15.5",
+    "@jupyterlab/cells": "^0.15.4",
     "@jupyterlab/coreutils": "^1.0.10",
     "@jupyterlab/docmanager": "^0.15.5",
     "@jupyterlab/fileeditor": "^0.15.4",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -70,7 +70,10 @@ function activateTOC(
   restorer.add(toc, 'juputerlab-toc');
 
   // Create a notebook TableOfContentsRegistry.IGenerator
-  const notebookGenerator = createNotebookGenerator(notebookTracker);
+  const notebookGenerator = createNotebookGenerator(
+    notebookTracker,
+    rendermime.sanitizer,
+  );
   registry.addGenerator(notebookGenerator);
 
   // Create an markdown editor TableOfContentsRegistry.IGenerator

--- a/src/generators.ts
+++ b/src/generators.ts
@@ -199,6 +199,10 @@ namespace Private {
     return headings;
   }
 
+  /**
+   * Given an HTML element, generate ToC headings
+   * by finding all the headers and making IHeading objects for them.
+   */
   export function getRenderedHTMLHeadings(
     node: HTMLElement,
     sanitizer: ISanitizer,
@@ -209,7 +213,8 @@ namespace Private {
       const heading = headingNodes[i];
       const level = parseInt(heading.tagName[1]);
       const text = heading.textContent;
-      const html = sanitizer.sanitize(heading.innerHTML, sanitizerOptions);
+      let html = sanitizer.sanitize(heading.innerHTML, sanitizerOptions);
+      html = html.replace('¶', ''); // Remove the anchor symbol.
 
       const onClick = () => {
         heading.scrollIntoView();

--- a/src/toc.tsx
+++ b/src/toc.tsx
@@ -151,7 +151,7 @@ export namespace TableOfContents {
 }
 
 /**
- * An object that represents a markdown heading.
+ * An object that represents a heading.
  */
 export interface IHeading {
   /**
@@ -170,6 +170,16 @@ export interface IHeading {
    * the parent widget to this item.
    */
   onClick: () => void;
+
+  /**
+   * If there is special markup, we can instead
+   * render the heading using a raw HTML string. This
+   * HTML *should be properly sanitized!*
+   *
+   * For instance, this can be used to render
+   * already-renderd-to-html markdown headings.
+   */
+  html?: string;
 }
 
 /**
@@ -219,11 +229,21 @@ export class TOCItem extends React.Component<ITOCItemProps, {}> {
       heading.onClick();
     };
 
-    return React.createElement(
-      `h${level}`,
-      {onClick: clickHandler},
-      <a href="">{heading.text}</a>,
-    );
+    if (heading.html) {
+      return React.createElement(
+        `h${level}`,
+        {
+          onClick: clickHandler,
+          dangerouslySetInnerHTML: {__html: heading.html},
+        },
+      );
+    } else {
+      return React.createElement(
+        `h${level}`,
+        {onClick: clickHandler},
+        <a href="">{heading.text}</a>,
+      );
+    }
   }
 }
 

--- a/src/toc.tsx
+++ b/src/toc.tsx
@@ -230,13 +230,11 @@ export class TOCItem extends React.Component<ITOCItemProps, {}> {
     };
 
     if (heading.html) {
-      return React.createElement(
-        `h${level}`,
-        {
-          onClick: clickHandler,
-          dangerouslySetInnerHTML: {__html: heading.html},
-        },
-      );
+      const el = React.createElement(`h${level}`, {
+        onClick: clickHandler,
+        dangerouslySetInnerHTML: {__html: heading.html},
+      });
+      return <a href="">{el}</a>;
     } else {
       return React.createElement(
         `h${level}`,


### PR DESCRIPTION
Fixes #8.

This allows for the parsing of rendered markdown cells, and when you click on the ToC item for headings when there are multiple in the same cell, it scrolls to the correct one.

It also will allow for a ToC for rendered markdown files if we expose a token for the markdown widget tracker in the core of JupyterLab.